### PR TITLE
Fix issue with using pydantic models used as default_factory

### DIFF
--- a/fast_depends/core/build.py
+++ b/fast_depends/core/build.py
@@ -21,6 +21,8 @@ from typing_extensions import (
     get_origin,
 )
 
+from pydantic._internal._signature import _HAS_DEFAULT_FACTORY_CLASS
+
 from fast_depends._compat import ConfigDict, create_model, get_config_base
 from fast_depends.core.model import CallModel, ResponseModel
 from fast_depends.dependencies import Depends
@@ -127,6 +129,9 @@ def build_call_model(
             var_keyword_arg = param_name
         elif param.default is inspect.Parameter.empty:
             default = Ellipsis
+        elif isinstance(param.default, _HAS_DEFAULT_FACTORY_CLASS):
+            # For pydantic default_factory inputs, this is used to mark the field
+            continue
         else:
             default = param.default
 

--- a/tests/test_prebuild.py
+++ b/tests/test_prebuild.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from fast_depends.core import build_call_model
-from fast_depends.use import inject
+from fast_depends.use import inject, Depends
 
 from .wrapper import noop_wrap
 
 
 class Model(BaseModel):
     a: str
+    b: list = Field(default_factory=list)
 
 
 def base_func(a: int) -> str:
@@ -41,3 +42,11 @@ def test_prebuild_with_wrapper() -> None:
     else:
         # pydantic v1
         call_model.model.update_forward_refs()
+
+
+def test_prebuild_with_inject_on_model() -> None:
+    @inject
+    def model_func(m: Model = Depends(Model)) -> Model:
+        return m
+
+    assert model_func(a="Hi!").b == []


### PR DESCRIPTION
This is not ready for a PR as it uses very new pydantic objects introduced in 2.10.x in November 2024. Would need some backwards compat to enforce same check to be released. 